### PR TITLE
Fix example for ball in README.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ Example:
 import numpy
 import quadpy
 
-scheme = quadpy.ball.hammer_stroud_14_3a()
+scheme = quadpy.ball.hammer_stroud_14_3()
 scheme.show()
 val = scheme.integrate(
     lambda x: numpy.exp(x[0]),


### PR DESCRIPTION
The scheme Hammer-Stroud 14_3 has no a, the correct name is hammer_stroud_14_3, so the example wouldn't work when copied.